### PR TITLE
fix: update dependencies to fix high vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "eslint-config-oclif-typescript": "3.1.7",
     "http-call": "^5.3.0",
     "json-schema-to-typescript": "^14.1.0",
-    "jsonwebtoken": "^8.3.0",
+    "jsonwebtoken": "^9.0.2",
     "typescript": "^4.9.5"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1553,10 +1553,10 @@ json5@^1.0.2:
   dependencies:
     minimist "^1.2.0"
 
-jsonwebtoken@^8.3.0:
-  version "8.5.1"
-  resolved "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz"
-  integrity sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==
+jsonwebtoken@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz"
+  integrity sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==
   dependencies:
     jws "^3.2.2"
     lodash.includes "^4.3.0"
@@ -1567,7 +1567,7 @@ jsonwebtoken@^8.3.0:
     lodash.isstring "^4.0.1"
     lodash.once "^4.0.0"
     ms "^2.1.1"
-    semver "^5.6.0"
+    semver "^7.5.4"
 
 jwa@^1.4.1:
   version "1.4.2"
@@ -1984,11 +1984,6 @@ safe-regex-test@^1.0.3:
     call-bind "^1.0.6"
     es-errors "^1.3.0"
     is-regex "^1.1.4"
-
-semver@^5.6.0:
-  version "5.7.2"
-  resolved "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz"
-  integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
 
 semver@^6.3.1:
   version "6.3.1"


### PR DESCRIPTION
## Description

This PR fixes the high vulnerabilities associated with this repo using the results from running `npm audit fix`. These vulnerability fixes required updating the `jsonwebtoken` dependency from `v8.5.1` to `v9.0.2`. However, none of the breaking changes from upgrading to the new major version affected the repo source code.

## Testing

N/A


## Screenshots (if applicable)
<img width="1375" height="122" alt="Screenshot 2025-07-29 at 11 57 09 AM" src="https://github.com/user-attachments/assets/12e16e78-d2c4-4682-a63a-27d03724bcf8" />




## SOC2 Compliance

Gus Work Item: [W-19111805](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002Il2LIYAZ/view) (Heroku internal)
