### PR TITLE
fix: make refreshACM send its acm_refresh body so cert auto-refresh works over the SDK

### DIFF
--- a/dist/3.sdk/routes.js
+++ b/dist/3.sdk/routes.js
@@ -395,7 +395,8 @@ export const app = {
   },
   "refreshACM": {
     "method": "PATCH",
-    "path": "/apps/{appIdentity}/acm"
+    "path": "/apps/{appIdentity}/acm",
+    "hasRequestBody": true
   }
 }
 

--- a/dist/3.sdk/types.d.ts
+++ b/dist/3.sdk/types.d.ts
@@ -1060,6 +1060,11 @@ export interface AppUpdateOpts {
   name?: string
 }
 
+/** Refresh ACM for an app */
+export interface AppRefreshACMOpts {
+  acm_refresh: boolean
+}
+
 /** An audit trail archive represents a monthly json zipped file containing events */
 export interface Archive {
   /** when archive was created */
@@ -5053,7 +5058,7 @@ export interface HerokuClient {
     /** Disable ACM flag for an app */
     disableACM(appIdentity: string): Promise<App>
     /** Refresh ACM for an app */
-    refreshACM(appIdentity: string): Promise<App>
+    refreshACM(appIdentity: string, requestBody: AppRefreshACMOpts): Promise<App>
   }
   /** An audit trail archive represents a monthly json zipped file containing events */
   archive: {

--- a/src/gen/normalize-hyperschema.ts
+++ b/src/gen/normalize-hyperschema.ts
@@ -13,6 +13,7 @@ import type {
   RouteDefinition,
 } from './schema-types.js'
 import { toPascalCase, toCamelCase, disambiguateLinkTitles } from './utils.js'
+import { patchHyperschema } from './patch-hyperschema.js'
 import type {
   AuxType,
   ClientResourceModel,
@@ -51,7 +52,14 @@ function dedupe(refs: TypeRef[]): TypeRef[] {
 }
 
 class HyperschemaNormalizer {
-  constructor(private schema: HerokuSchema) {}
+  constructor(private schema: HerokuSchema) {
+    // Apply targeted upstream-hyperschema patches (e.g. the missing Refresh ACM
+    // request body) at the single choke point every entry point traverses:
+    // both normalizeHyperschema() and extractRouteEntries() construct a
+    // HyperschemaNormalizer, so patching here keeps production output and test
+    // expectations in lockstep. Self-heals to a no-op if upstream is fixed.
+    patchHyperschema(schema)
+  }
 
   normalize(): TypesModel {
     const resources: ResourceModel[] = []

--- a/src/gen/patch-hyperschema.test.ts
+++ b/src/gen/patch-hyperschema.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import { generateTypes } from './generator.js'
+import { generateRoutesJS } from './route-generator.js'
+import { patchHyperschema } from './patch-hyperschema.js'
+import type { HerokuSchema } from './schema-types.js'
+
+// The upstream hyperschema omits the request body on the app "Refresh ACM"
+// PATCH link, so the generator would emit no requestBody param and no
+// hasRequestBody flag. patchHyperschema injects { acm_refresh: boolean } so
+// both outputs reflect what the API actually requires. These tests exercise
+// the injection through the shared normalizer path (generateTypes /
+// generateRoutesJS), the same path the golden test uses.
+
+function appWithRefreshACM(): HerokuSchema {
+  return {
+    definitions: {
+      app: {
+        definitions: {
+          identity: { type: ['string'] },
+        },
+        links: [
+          {
+            title: 'Refresh ACM',
+            description: 'Refresh ACM for an app',
+            method: 'PATCH',
+            rel: 'update',
+            href: '/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/acm',
+            targetSchema: { $ref: '#/definitions/app' },
+          },
+        ],
+      },
+    },
+  }
+}
+
+describe('patchHyperschema Refresh ACM injection', () => {
+  it('emits AppRefreshACMOpts and a requestBody param after normalization', () => {
+    const types = generateTypes(appWithRefreshACM())
+    expect(types).toContain('export interface AppRefreshACMOpts')
+    expect(types).toContain('refreshACM(appIdentity: string, requestBody: AppRefreshACMOpts)')
+  })
+
+  it('sets hasRequestBody: true on the refreshACM route', () => {
+    const routes = generateRoutesJS(appWithRefreshACM())
+    expect(routes).toContain('"refreshACM"')
+    expect(routes).toContain('"hasRequestBody": true')
+  })
+
+  it('injects the acm_refresh boolean schema onto a schema-less link', () => {
+    const schema = appWithRefreshACM()
+    patchHyperschema(schema)
+    const link = schema.definitions.app.links!.find(l => l.title === 'Refresh ACM')!
+    expect(link.schema).toEqual({
+      type: ['object'],
+      properties: { acm_refresh: { type: ['boolean'] } },
+      required: ['acm_refresh'],
+    })
+  })
+
+  it('leaves a link that already has a schema untouched', () => {
+    const schema = appWithRefreshACM()
+    const existing = {
+      type: ['object'],
+      properties: { custom: { type: ['string'] } },
+    }
+    schema.definitions.app.links![0].schema = existing
+    patchHyperschema(schema)
+    expect(schema.definitions.app.links![0].schema).toBe(existing)
+  })
+
+  it('does not throw when there is no app definition', () => {
+    const schema: HerokuSchema = { definitions: {} }
+    expect(() => patchHyperschema(schema)).not.toThrow()
+    expect(patchHyperschema(schema)).toBe(schema)
+  })
+
+  it('does not throw when app has no matching Refresh ACM link', () => {
+    const schema: HerokuSchema = {
+      definitions: {
+        app: {
+          links: [
+            { title: 'Info', method: 'GET', href: '/apps/{id}' },
+          ],
+        },
+      },
+    }
+    expect(() => patchHyperschema(schema)).not.toThrow()
+    expect(schema.definitions.app.links![0].schema).toBeUndefined()
+  })
+})

--- a/src/gen/patch-hyperschema.ts
+++ b/src/gen/patch-hyperschema.ts
@@ -1,0 +1,37 @@
+// Targeted hyperschema patches for gaps in the upstream Heroku hyperschema.
+//
+// WHY: The upstream hyperschema's "Refresh ACM" link (PATCH /apps/{id}/acm)
+// on the `app` definition ships with NO `schema` block at all — the key is
+// absent (not null). Unlike the sibling "Update" link, it declares no request
+// body, so the generator emits neither a `requestBody` param on the TS method
+// nor a `hasRequestBody: true` flag on the route. But the API actually requires
+// `{ acm_refresh: true }`, so the SDK dispatcher silently drops the body.
+//
+// Eric (Heroku architect) authorized making @heroku/types reflect the reality
+// of what the web service accepts, even ahead of an upstream hyperschema fix:
+//   "i'd try to make changes to the sdk/heroku types to reflect what the
+//    reality is in web services, even if it's 'wrong'."
+//
+// We inject the missing schema here. The guard only fires when the link exists
+// and has NO schema, so this SELF-HEALS to a no-op if upstream ever adds the
+// schema block itself.
+
+import type { HerokuSchema, SchemaNode } from './schema-types.js'
+
+const REFRESH_ACM_SCHEMA: SchemaNode = {
+  type: ['object'],
+  properties: { acm_refresh: { type: ['boolean'] } },
+  required: ['acm_refresh'],
+}
+
+// Mutates `schema` in place and returns it for chaining.
+export function patchHyperschema(schema: HerokuSchema): HerokuSchema {
+  const app = schema.definitions?.['app']
+  const link = app?.links?.find(
+    l => l.title === 'Refresh ACM' && l.method?.toUpperCase() === 'PATCH',
+  )
+  if (link && !link.schema) {
+    link.schema = REFRESH_ACM_SCHEMA
+  }
+  return schema
+}

--- a/src/gen/patch-hyperschema.ts
+++ b/src/gen/patch-hyperschema.ts
@@ -7,10 +7,8 @@
 // nor a `hasRequestBody: true` flag on the route. But the API actually requires
 // `{ acm_refresh: true }`, so the SDK dispatcher silently drops the body.
 //
-// Eric (Heroku architect) authorized making @heroku/types reflect the reality
-// of what the web service accepts, even ahead of an upstream hyperschema fix:
-//   "i'd try to make changes to the sdk/heroku types to reflect what the
-//    reality is in web services, even if it's 'wrong'."
+// We patch @heroku/types to reflect what the web service actually accepts,
+// rather than blocking on an upstream hyperschema fix.
 //
 // We inject the missing schema here. The guard only fires when the link exists
 // and has NO schema, so this SELF-HEALS to a no-op if upstream ever adds the

--- a/tests/__golden__/3.sdk-types.d.ts
+++ b/tests/__golden__/3.sdk-types.d.ts
@@ -1056,6 +1056,11 @@ export interface AppUpdateOpts {
   name?: string
 }
 
+/** Refresh ACM for an app */
+export interface AppRefreshACMOpts {
+  acm_refresh: boolean
+}
+
 /** An audit trail archive represents a monthly json zipped file containing events */
 export interface Archive {
   /** when archive was created */
@@ -5049,7 +5054,7 @@ export interface HerokuClient {
   /** Disable ACM flag for an app */
   disableACM(appIdentity: string): Promise<App>
   /** Refresh ACM for an app */
-  refreshACM(appIdentity: string): Promise<App>
+  refreshACM(appIdentity: string, requestBody: AppRefreshACMOpts): Promise<App>
   }
   /** An audit trail archive represents a monthly json zipped file containing events */
   archive: {


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary

Makes the generated refreshACM method actually send its request body, so PATCH /apps/{id}/acm includes {acm_refresh: true } instead of an empty body. This unblocks migrating the CLI's certs:auto:refresh command onto the SDK.

**Why, is something broken?**

The upstream hyperschema's "Refresh ACM" link ships with no schema block, so the generator never emitted a requestBody param or the hasRequestBody route flag... and the SDK dropped the body.

This fix started in Slack in this discussion: https://salesforce-internal.slack.com/archives/C048U82QVKQ/p1784568350711309?thread_ts=1784204631.074229&cid=C048U82QVKQ

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [x] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing

CI only runs npm test (and not on the PR itself), so please run this locally to verify:
- npm test          # 127/127, includes the golden byte-for-byte test — the real correctness gate
- npm run typecheck # clean (CI does NOT run this)
- grep -A3 '"refreshACM"' dist/3.sdk/routes.js    # shows "hasRequestBody": true
- grep -n AppRefreshACMOpts dist/3.sdk/types.d.ts # interface + param present

## Screenshots (if applicable)

## Related Issues
GUS work item: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eHYVDYA4/view
