### PR TITLE
feat: add metrics support

### DIFF
--- a/dist/metrics/routes.d.ts
+++ b/dist/metrics/routes.d.ts
@@ -1,0 +1,9 @@
+/**
+ * NOTE: the contents of this file are generated. Do not modify this file.
+ */
+
+import type { RouteDefinition } from '../types'
+
+export declare const formationMetric: Record<string, RouteDefinition>
+
+export declare const routerMetric: Record<string, RouteDefinition>

--- a/dist/metrics/routes.js
+++ b/dist/metrics/routes.js
@@ -1,0 +1,28 @@
+/**
+ * NOTE: the contents of this file are generated. Do not modify this file.
+ */
+
+export const routerMetric = {
+    latency: {
+        method: 'GET',
+        path: '/apps/{app}/router-metrics/latency',
+        query: ['start_time', 'end_time', 'step', 'process_type'],
+    },
+    errors: {
+        method: 'GET',
+        path: '/apps/{app}/router-metrics/errors',
+        query: ['start_time', 'end_time', 'step', 'process_type'],
+    },
+    status: {
+        method: 'GET',
+        path: '/apps/{app}/router-metrics/status',
+        query: ['start_time', 'end_time', 'step', 'process_type'],
+    },
+};
+export const formationMetric = {
+    errors: {
+        method: 'GET',
+        path: '/apps/{app}/formation/{formationType}/metrics/errors',
+        query: ['start_time', 'end_time', 'step'],
+    },
+};

--- a/dist/metrics/types.d.ts
+++ b/dist/metrics/types.d.ts
@@ -1,0 +1,61 @@
+/**
+ * NOTE: the contents of this file are generated. Do not modify this file.
+ */
+
+export interface FormationMetricErrorsResult {
+  data: Record<string, unknown>
+  start_time: string
+  end_time: string
+  step: string
+}
+
+export interface RouterMetricLatencyResult {
+  data: Record<string, unknown>
+  start_time: string
+  end_time: string
+  step: string
+}
+
+export interface RouterMetricErrorsResult {
+  data: Record<string, unknown>
+  start_time: string
+  end_time: string
+  step: string
+}
+
+export interface RouterMetricStatusResult {
+  data: Record<string, unknown>
+  start_time: string
+  end_time: string
+  step: string
+}
+
+export interface HerokuClient {
+  formationMetric: {
+  errors(app: string, formationType: string, query: {
+  start_time?: string
+  end_time?: string
+  step?: string
+}): Promise<FormationMetricErrorsResult>
+  }
+  routerMetric: {
+  latency(app: string, query: {
+  start_time?: string
+  end_time?: string
+  step?: string
+  process_type?: string
+}): Promise<RouterMetricLatencyResult>
+  errors(app: string, query: {
+  start_time?: string
+  end_time?: string
+  step?: string
+  process_type?: string
+}): Promise<RouterMetricErrorsResult>
+  status(app: string, query: {
+  start_time?: string
+  end_time?: string
+  step?: string
+  process_type?: string
+}): Promise<RouterMetricStatusResult>
+  }
+}

--- a/dist/metrics/types.d.ts
+++ b/dist/metrics/types.d.ts
@@ -3,31 +3,31 @@
  */
 
 export interface FormationMetricErrorsResult {
-  data: Record<string, unknown>
+  data: Record<string, Array<number | null>>
   start_time: string
   end_time: string
-  step: string
+  step: number
 }
 
 export interface RouterMetricLatencyResult {
-  data: Record<string, unknown>
+  data: Record<string, Array<number | null>>
   start_time: string
   end_time: string
-  step: string
+  step: number
 }
 
 export interface RouterMetricErrorsResult {
-  data: Record<string, unknown>
+  data: Record<string, Array<number | null>>
   start_time: string
   end_time: string
-  step: string
+  step: number
 }
 
 export interface RouterMetricStatusResult {
-  data: Record<string, unknown>
+  data: Record<string, Array<number | null>>
   start_time: string
   end_time: string
-  step: string
+  step: number
 }
 
 export interface HerokuClient {

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -6,4 +6,5 @@ export interface RouteDefinition {
   method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
   path: string
   hasRequestBody?: true
+  query?: string[]
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,13 @@
       "types": "./dist/data/routes.d.ts",
       "default": "./dist/data/routes.js"
     },
+    "./metrics": {
+      "types": "./dist/metrics/types.d.ts"
+    },
+    "./metrics/routes": {
+      "types": "./dist/metrics/routes.d.ts",
+      "default": "./dist/metrics/routes.js"
+    },
     "./types": {
       "types": "./dist/types.d.ts"
     }
@@ -40,6 +47,7 @@
     "typecheck": "tsc --noEmit",
     "generate": "tsx src/cli.ts",
     "generate:data": "tsx src/gen-data-types.ts",
+    "generate:metrics": "tsx src/gen-metrics-types.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage"

--- a/src/gen-data-types.test.ts
+++ b/src/gen-data-types.test.ts
@@ -114,6 +114,27 @@ describe('generateDataTypes', () => {
   })
 })
 
+describe('query params', () => {
+  it('emits a trailing query object param for routes declaring query', () => {
+    const out = generateDataTypes(
+      {
+        routerMetric: {
+          latency: { method: 'GET', path: '/apps/{app}/router-metrics/latency', query: ['date', 'process_type'] },
+        },
+      },
+      {
+        'GET /apps/:app/router-metrics/latency': {
+          request: null,
+          responses: { '200': { type: 'object', properties: { step: { type: 'string' } } } },
+          request_example_count: 0,
+          response_example_count: 0,
+        },
+      },
+    )
+    expect(out).toMatch(/latency\(app: string, query: \{[^}]*date\?: string[^}]*process_type\?: string[^}]*\}\): Promise</)
+  })
+})
+
 describe('main', () => {
   function makeDeps(over: Partial<MainDeps> = {}): MainDeps {
     return {

--- a/src/gen-data-types.test.ts
+++ b/src/gen-data-types.test.ts
@@ -114,6 +114,39 @@ describe('generateDataTypes', () => {
   })
 })
 
+describe('additionalProperties', () => {
+  it('emits a typed Record for a property-less object with typed additionalProperties', () => {
+    const out = generateDataTypes(
+      { app: { series: { method: 'GET', path: '/series' } } },
+      {
+        'GET /series': routeSchema({
+          responses: {
+            '200': {
+              type: 'object',
+              required: ['data'],
+              properties: {
+                data: {
+                  type: 'object',
+                  additionalProperties: { type: 'array', items: { type: ['number', 'null'] } },
+                },
+              },
+            },
+          },
+        }),
+      },
+    )
+    expect(out).toMatch(/data: Record<string, Array<number \| null>>/)
+  })
+
+  it('still falls back to Record<string, unknown> when additionalProperties is absent', () => {
+    const out = generateDataTypes(
+      { app: { blob: { method: 'GET', path: '/blob' } } },
+      { 'GET /blob': routeSchema({ responses: { '200': { type: 'object' } } }) },
+    )
+    expect(out).toContain('export type AppBlobResult = Record<string, unknown>')
+  })
+})
+
 describe('query params', () => {
   it('emits a trailing query object param for routes declaring query', () => {
     const out = generateDataTypes(

--- a/src/gen-metrics-types.test.ts
+++ b/src/gen-metrics-types.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest'
+import { generateMetricsTypes, main, type MainDeps } from './gen-metrics-types.js'
+import { routerMetric, formationMetric } from './metrics/routes.js'
+
+const schemas = JSON.parse(
+  (await import('node:fs')).readFileSync(new URL('./metrics/schemas.json', import.meta.url), 'utf8'),
+)
+
+describe('generateMetricsTypes', () => {
+  it('emits HerokuClient with routerMetric + formationMetric and query params', () => {
+    const out = generateMetricsTypes({ routerMetric, formationMetric }, schemas)
+    expect(out).toContain('export interface HerokuClient {')
+    expect(out).toContain('routerMetric: {')
+    expect(out).toContain('formationMetric: {')
+    // router latency: app path param + query object
+    expect(out).toMatch(/latency\(app: string, query: \{[\s\S]*?process_type\?: string[\s\S]*?\}\): Promise</)
+    // formation errors: app + formationType path params + query object (no process_type)
+    expect(out).toMatch(/errors\(app: string, formationType: string, query: \{[\s\S]*?step\?: string[\s\S]*?\}\): Promise</)
+    // response Result carries the metrics fields
+    expect(out).toMatch(/start_time\??: string/)
+  })
+})
+
+describe('main (metrics driver)', () => {
+  it('writes routes.js, routes.d.ts, and types.d.ts', async () => {
+    const writes: Record<string, string> = {}
+    const deps: Partial<MainDeps> = {
+      writeFile: (p, c) => { writes[p] = c },
+      emitTypedSource: () => ({ jsPath: '/fake/dist/metrics/routes.js', diagnostics: [] }),
+      log: () => {},
+    }
+    await main(deps)
+    const keys = Object.keys(writes)
+    expect(keys.some(k => k.endsWith('metrics/types.d.ts'))).toBe(true)
+    expect(keys.some(k => k.endsWith('metrics/routes.d.ts'))).toBe(true)
+    expect(writes[keys.find(k => k.endsWith('metrics/routes.d.ts'))!]).toContain('routerMetric')
+    // Verify the shared dist/types.d.ts is rewritten with query field (NOT under metrics/)
+    const sharedKey = keys.find(k => k.endsWith('types.d.ts') && !k.includes('metrics'))
+    expect(sharedKey).toBeTruthy()
+    expect(writes[sharedKey!]).toContain('query?: string[]')
+  })
+})

--- a/src/gen-metrics-types.ts
+++ b/src/gen-metrics-types.ts
@@ -1,0 +1,113 @@
+/**
+ * Code generator for `metrics/types.d.ts`.
+ *
+ * Reads:
+ *   - metrics/routes.ts       (hand-written resource grouping; (method, path, query) per call)
+ *   - metrics/schemas.json    (local response schemas keyed by "VERB /path")
+ *
+ * Emits dist/metrics/{types.d.ts, routes.js, routes.d.ts}. Mirrors the data
+ * pipeline (gen-data-types.ts) but sources its schema from a committed local
+ * file rather than Shogun.
+ *
+ * Usage: tsx src/gen-metrics-types.ts
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import { emitTypes } from "./gen/ts-emit.js";
+import {
+  normalizeData,
+  summarizeCoverage,
+  type RouteDef,
+  type RouteSchema,
+} from "./gen/normalize-data.js";
+import { emitTypedSource as defaultEmitTypedSource, type EmitTypedSourceResult } from "./gen/emit-typed-source.js";
+import { GENERATED_CONTENT_PREAMBLE } from "./gen/generator.js";
+import { generateRoutesDTSForResources, generateSharedTypesDTS } from "./gen/route-generator.js";
+
+const BANNER = "/**\n * NOTE: the contents of this file are generated. Do not modify this file.\n */\n";
+
+export function generateMetricsTypes(
+  routesByResource: Record<string, Record<string, RouteDef>>,
+  schemas: Record<string, RouteSchema>,
+): string {
+  const model = normalizeData(routesByResource, schemas);
+  return BANNER + "\n" + emitTypes(model, { emitResourceShapes: false });
+}
+
+export interface MainDeps {
+  routesPath: string
+  schemaPath: string
+  outPath: string
+  readFile: (path: string) => string
+  writeFile: (path: string, content: string) => void
+  importRoutes: (path: string) => Promise<Record<string, unknown>>
+  emitTypedSource: (opts: { sourcePath: string; rootDir: string; outDir: string; banner?: string }) => EmitTypedSourceResult
+  log: (message: string) => void
+}
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SRC = HERE;
+const DIST = resolve(HERE, "../dist");
+
+const defaultDeps: MainDeps = {
+  routesPath: resolve(SRC, "metrics/routes.ts"),
+  schemaPath: resolve(SRC, "metrics/schemas.json"),
+  outPath: resolve(DIST, "metrics/types.d.ts"),
+  readFile: (p) => readFileSync(p, "utf8"),
+  writeFile: writeFileSync,
+  importRoutes: (p) => import(p),
+  emitTypedSource: defaultEmitTypedSource,
+  log: (m) => console.log(m),
+};
+
+export async function main(deps: Partial<MainDeps> = {}) {
+  const { routesPath, schemaPath, outPath, readFile, writeFile, importRoutes, emitTypedSource, log } = { ...defaultDeps, ...deps };
+
+  const routesModule = await importRoutes(routesPath);
+  const routesByResource: Record<string, Record<string, RouteDef>> = {};
+  for (const [k, v] of Object.entries(routesModule)) {
+    if (k !== "default") routesByResource[k] = v as Record<string, RouteDef>;
+  }
+
+  const schemas: Record<string, RouteSchema> = JSON.parse(readFile(schemaPath));
+  const output = generateMetricsTypes(routesByResource, schemas);
+
+  const emitResult = emitTypedSource({
+    sourcePath: routesPath,
+    rootDir: SRC,
+    outDir: DIST,
+    banner: GENERATED_CONTENT_PREAMBLE,
+  });
+  if (emitResult.diagnostics.length > 0) {
+    const summary = emitResult.diagnostics.map(d => ts.flattenDiagnosticMessageText(d.messageText, '\n')).join('\n')
+    throw new Error(`emitTypedSource returned ${emitResult.diagnostics.length} diagnostic(s):\n${summary}`)
+  }
+
+  const routesDtsPath = resolve(DIST, "metrics/routes.d.ts");
+  writeFile(routesDtsPath, GENERATED_CONTENT_PREAMBLE + generateRoutesDTSForResources(Object.keys(routesByResource)));
+  writeFile(outPath, output);
+
+  // Rewrite the SHARED dist/types.d.ts so the `query?: string[]` field added in
+  // A1 actually lands on disk. Normally only `npm run generate` writes this file,
+  // and that fetches the hyperschema over the network. We regenerate just the
+  // shared RouteDefinition block here from the pure emitter — no network — so the
+  // SDK (which imports RouteDefinition from `@heroku/types/types`) can typecheck
+  // `route.query`. VERIFIED during planning: dist/types.d.ts today contains ONLY
+  // the RouteDefinition interface, so this full-file overwrite is lossless.
+  const sharedTypesPath = resolve(DIST, "types.d.ts");
+  writeFile(sharedTypesPath, GENERATED_CONTENT_PREAMBLE + generateSharedTypesDTS());
+
+  const s = summarizeCoverage(routesByResource, schemas);
+  log(`Wrote ${outPath}`);
+  log(`Wrote ${emitResult.jsPath}`);
+  log(`Wrote ${routesDtsPath}`);
+  log(`Wrote ${sharedTypesPath}`);
+  log(`  Methods total:        ${s.total}`);
+  log(`  With any schema:      ${s.withSchema} (${(100 * s.withSchema / s.total).toFixed(1)}%)`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main()
+}

--- a/src/gen/normalize-data.ts
+++ b/src/gen/normalize-data.ts
@@ -27,6 +27,7 @@ export interface JsonSchema {
   required?: string[]
   items?: JsonSchema
   anyOf?: JsonSchema[]
+  additionalProperties?: JsonSchema | boolean
 }
 
 export interface RouteSchema {
@@ -115,7 +116,13 @@ function objectSchemaToTypeRef(schema: JsonSchema): TypeRef {
   const props = schema.properties ?? {}
   const keys = Object.keys(props)
   if (keys.length === 0) {
-    return { kind: 'record', valueType: { kind: 'primitive', primitive: 'unknown' } }
+    // A property-less object with a typed `additionalProperties` becomes a
+    // typed record (e.g. `Record<string, (number | null)[]>`); without one it
+    // falls back to the permissive `Record<string, unknown>`.
+    const valueType = typeof schema.additionalProperties === 'object'
+      ? schemaToTypeRef(schema.additionalProperties)
+      : { kind: 'primitive', primitive: 'unknown' } as TypeRef
+    return { kind: 'record', valueType }
   }
   return { kind: 'object', shape: buildObjectShape(schema) }
 }

--- a/src/gen/normalize-data.ts
+++ b/src/gen/normalize-data.ts
@@ -18,6 +18,7 @@ export interface RouteDef {
   method: string
   path: string
   hasRequestBody?: true
+  query?: string[]
 }
 
 export interface JsonSchema {
@@ -246,6 +247,21 @@ function buildMethod(
   }))
   if (p.optsName && optsEmitted.has(p.optsName)) {
     params.push({ name: 'requestBody', type: { kind: 'reference', name: p.optsName } })
+  }
+  if (p.route.query && p.route.query.length > 0) {
+    params.push({
+      name: 'query',
+      type: {
+        kind: 'object',
+        shape: {
+          properties: p.route.query.map(key => ({
+            key,
+            type: { kind: 'primitive', primitive: 'string' },
+            required: false,
+          })),
+        },
+      },
+    })
   }
   const returnType: TypeRef = resultEmitted.has(p.resultName)
     ? { kind: 'reference', name: p.resultName }

--- a/src/gen/route-generator.test.ts
+++ b/src/gen/route-generator.test.ts
@@ -122,6 +122,14 @@ describe('generateSharedTypesDTS', () => {
     const dts = generateSharedTypesDTS()
     expect(dts).toContain(`method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'`)
   })
+
+  it('emits RouteDefinition with an optional query field', () => {
+    const out = generateSharedTypesDTS()
+    expect(out).toContain('method:')
+    expect(out).toContain('path: string')
+    expect(out).toContain('hasRequestBody?: true')
+    expect(out).toContain('query?: string[]')
+  })
 })
 
 function parseExport(js: string, name: string): Record<string, Record<string, unknown>> {

--- a/src/gen/route-generator.ts
+++ b/src/gen/route-generator.ts
@@ -17,6 +17,9 @@ function formatResourceJS({ resource, entries }: ResourceRoutes): string {
     if (entry.hasRequestBody) {
       route.hasRequestBody = true
     }
+    if (entry.query) {
+      route.query = entry.query
+    }
     methods[toCamelCase(entry.titleKey)] = route
   }
   return `export const ${toCamelCase(resource)} = ${JSON.stringify(methods, null, 2)}`
@@ -28,7 +31,7 @@ function formatResourceDTS(resource: string): string {
 
 export function generateSharedTypesDTS(): string {
   const methodUnion = HTTP_METHODS.map(m => `'${m}'`).join(' | ')
-  return `export interface RouteDefinition {\n  method: ${methodUnion}\n  path: string\n  hasRequestBody?: true\n}\n`
+  return `export interface RouteDefinition {\n  method: ${methodUnion}\n  path: string\n  hasRequestBody?: true\n  query?: string[]\n}\n`
 }
 
 export function generateRoutesJS(schema: HerokuSchema): string {

--- a/src/gen/schema-types.ts
+++ b/src/gen/schema-types.ts
@@ -59,4 +59,5 @@ export interface RouteDefinition {
   method: HttpMethod
   path: string
   hasRequestBody?: true
+  query?: string[]
 }

--- a/src/metrics/routes.test.ts
+++ b/src/metrics/routes.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { routerMetric, formationMetric } from './routes.js'
+
+describe('metrics routes', () => {
+  it('declares the three router-metric GET routes with query params', () => {
+    expect(routerMetric.latency).toEqual({
+      method: 'GET',
+      path: '/apps/{app}/router-metrics/latency',
+      query: ['start_time', 'end_time', 'step', 'process_type'],
+    })
+    expect(routerMetric.errors.path).toBe('/apps/{app}/router-metrics/errors')
+    expect(routerMetric.status.path).toBe('/apps/{app}/router-metrics/status')
+    for (const r of Object.values(routerMetric)) {
+      expect(r.method).toBe('GET')
+      expect(r.query).toContain('process_type')
+    }
+  })
+
+  it('declares the formation-metric errors route (no process_type query)', () => {
+    expect(formationMetric.errors).toEqual({
+      method: 'GET',
+      path: '/apps/{app}/formation/{formationType}/metrics/errors',
+      query: ['start_time', 'end_time', 'step'],
+    })
+  })
+})

--- a/src/metrics/routes.ts
+++ b/src/metrics/routes.ts
@@ -1,0 +1,27 @@
+import type { RouteDefinition } from '../gen/schema-types.js'
+
+export const routerMetric = {
+  latency: {
+    method: 'GET',
+    path: '/apps/{app}/router-metrics/latency',
+    query: ['start_time', 'end_time', 'step', 'process_type'],
+  },
+  errors: {
+    method: 'GET',
+    path: '/apps/{app}/router-metrics/errors',
+    query: ['start_time', 'end_time', 'step', 'process_type'],
+  },
+  status: {
+    method: 'GET',
+    path: '/apps/{app}/router-metrics/status',
+    query: ['start_time', 'end_time', 'step', 'process_type'],
+  },
+} as const satisfies Record<string, RouteDefinition>
+
+export const formationMetric = {
+  errors: {
+    method: 'GET',
+    path: '/apps/{app}/formation/{formationType}/metrics/errors',
+    query: ['start_time', 'end_time', 'step'],
+  },
+} as const satisfies Record<string, RouteDefinition>

--- a/src/metrics/routes.ts
+++ b/src/metrics/routes.ts
@@ -1,3 +1,12 @@
+// Hand-authored route registry for api.metrics.heroku.com. NOT code-generated
+// (the metrics service has no hyperschema). Paths and query params verified
+// 2026-08-04 against github.com/heroku/metaas — the Go service behind the API:
+//   - routes: cmd/metrics-api/main.go
+//   - query params: v2/serializers/request.go (start_time, end_time, step,
+//     process_type; also `region`, intentionally omitted here as no CLI
+//     consumer uses it). `process_type` is read but ignored for router-metrics
+//     and meaningful only for formation metrics.
+// If metaas changes these, update this file by hand.
 import type { RouteDefinition } from '../gen/schema-types.js'
 
 export const routerMetric = {

--- a/src/metrics/schemas.json
+++ b/src/metrics/schemas.json
@@ -1,0 +1,70 @@
+{
+  "GET /apps/:app/router-metrics/latency": {
+    "request": null,
+    "responses": {
+      "200": {
+        "type": "object",
+        "required": ["data", "start_time", "end_time", "step"],
+        "properties": {
+          "data": { "type": "object" },
+          "start_time": { "type": "string" },
+          "end_time": { "type": "string" },
+          "step": { "type": "string" }
+        }
+      }
+    },
+    "request_example_count": 0,
+    "response_example_count": 0
+  },
+  "GET /apps/:app/router-metrics/errors": {
+    "request": null,
+    "responses": {
+      "200": {
+        "type": "object",
+        "required": ["data", "start_time", "end_time", "step"],
+        "properties": {
+          "data": { "type": "object" },
+          "start_time": { "type": "string" },
+          "end_time": { "type": "string" },
+          "step": { "type": "string" }
+        }
+      }
+    },
+    "request_example_count": 0,
+    "response_example_count": 0
+  },
+  "GET /apps/:app/router-metrics/status": {
+    "request": null,
+    "responses": {
+      "200": {
+        "type": "object",
+        "required": ["data", "start_time", "end_time", "step"],
+        "properties": {
+          "data": { "type": "object" },
+          "start_time": { "type": "string" },
+          "end_time": { "type": "string" },
+          "step": { "type": "string" }
+        }
+      }
+    },
+    "request_example_count": 0,
+    "response_example_count": 0
+  },
+  "GET /apps/:app/formation/:formationType/metrics/errors": {
+    "request": null,
+    "responses": {
+      "200": {
+        "type": "object",
+        "required": ["data", "start_time", "end_time", "step"],
+        "properties": {
+          "data": { "type": "object" },
+          "start_time": { "type": "string" },
+          "end_time": { "type": "string" },
+          "step": { "type": "string" }
+        }
+      }
+    },
+    "request_example_count": 0,
+    "response_example_count": 0
+  }
+}

--- a/src/metrics/schemas.json
+++ b/src/metrics/schemas.json
@@ -1,4 +1,5 @@
 {
+  "$comment": "Hand-authored response schemas for api.metrics.heroku.com. NOT code-generated. Verified 2026-08-04 against github.com/heroku/metaas (v2/serializers/response.go, v2/models/points.go): all four endpoints return { start_time: time.Time (RFC3339), end_time: time.Time (RFC3339), step: int minutes, data: map[string][]*float64 }. `data` keys vary by endpoint (latency: latency.ms.p50/p95/p99/max; errors: router/dyno event codes like H12/R14; status: status_2xx/4xx/5xx). Values are per-time-bucket series aligned to start_time + n*step.",
   "GET /apps/:app/router-metrics/latency": {
     "request": null,
     "responses": {
@@ -6,10 +7,13 @@
         "type": "object",
         "required": ["data", "start_time", "end_time", "step"],
         "properties": {
-          "data": { "type": "object" },
+          "data": {
+            "type": "object",
+            "additionalProperties": { "type": "array", "items": { "type": ["number", "null"] } }
+          },
           "start_time": { "type": "string" },
           "end_time": { "type": "string" },
-          "step": { "type": "string" }
+          "step": { "type": "integer" }
         }
       }
     },
@@ -23,10 +27,13 @@
         "type": "object",
         "required": ["data", "start_time", "end_time", "step"],
         "properties": {
-          "data": { "type": "object" },
+          "data": {
+            "type": "object",
+            "additionalProperties": { "type": "array", "items": { "type": ["number", "null"] } }
+          },
           "start_time": { "type": "string" },
           "end_time": { "type": "string" },
-          "step": { "type": "string" }
+          "step": { "type": "integer" }
         }
       }
     },
@@ -40,10 +47,13 @@
         "type": "object",
         "required": ["data", "start_time", "end_time", "step"],
         "properties": {
-          "data": { "type": "object" },
+          "data": {
+            "type": "object",
+            "additionalProperties": { "type": "array", "items": { "type": ["number", "null"] } }
+          },
           "start_time": { "type": "string" },
           "end_time": { "type": "string" },
-          "step": { "type": "string" }
+          "step": { "type": "integer" }
         }
       }
     },
@@ -57,10 +67,13 @@
         "type": "object",
         "required": ["data", "start_time", "end_time", "step"],
         "properties": {
-          "data": { "type": "object" },
+          "data": {
+            "type": "object",
+            "additionalProperties": { "type": "array", "items": { "type": ["number", "null"] } }
+          },
           "start_time": { "type": "string" },
           "end_time": { "type": "string" },
-          "step": { "type": "string" }
+          "step": { "type": "integer" }
         }
       }
     },


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary

Add support for the new metrics service.  This is a support PR for adding the service to the SDK next.

Add a @heroku/types subpath for api.metrics.heroku.com, mirroring the data/3.sdk variants. Four GET endpoints under two resources: routerMetric (latency, errors, status) and formationMetric (errors).

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [x] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing

CI should be fine

## Screenshots (if applicable)

## Related Issues
GUS work item: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eLjcZYAS/view
