### PR TITLE
feat: add Dashboard Backend favorite route types

### DIFF
--- a/dist/dashboard-backend/routes.d.ts
+++ b/dist/dashboard-backend/routes.d.ts
@@ -1,0 +1,7 @@
+/**
+ * NOTE: the contents of this file are generated. Do not modify this file.
+ */
+
+import type { RouteDefinition } from '../types'
+
+export declare const favorite: Record<string, RouteDefinition>

--- a/dist/dashboard-backend/routes.js
+++ b/dist/dashboard-backend/routes.js
@@ -1,0 +1,20 @@
+/**
+ * NOTE: the contents of this file are generated. Do not modify this file.
+ */
+
+export const favorite = {
+    list: {
+        method: 'GET',
+        path: '/favorites',
+        query: ['type'],
+    },
+    create: {
+        method: 'POST',
+        path: '/favorites',
+        hasRequestBody: true,
+    },
+    delete: {
+        method: 'DELETE',
+        path: '/favorites/{id}',
+    },
+};

--- a/dist/dashboard-backend/types.d.ts
+++ b/dist/dashboard-backend/types.d.ts
@@ -1,0 +1,31 @@
+/**
+ * NOTE: the contents of this file are generated. Do not modify this file.
+ */
+
+export type FavoriteListResult = Array<{
+  id: string
+  resource_id: string
+  resource_name: string
+  type: string
+}>
+
+export interface FavoriteCreateOpts {
+  resource_id: string
+  type: string
+}
+
+export interface FavoriteCreateResult {
+  id: string
+  resource_id: string
+  type: string
+}
+
+export interface HerokuClient {
+  favorite: {
+  list(query: {
+  type?: string
+}): Promise<FavoriteListResult>
+  create(requestBody: FavoriteCreateOpts): Promise<FavoriteCreateResult | void>
+  delete(id: string): Promise<void>
+  }
+}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,13 @@
       "types": "./dist/data/routes.d.ts",
       "default": "./dist/data/routes.js"
     },
+    "./dashboard-backend": {
+      "types": "./dist/dashboard-backend/types.d.ts"
+    },
+    "./dashboard-backend/routes": {
+      "types": "./dist/dashboard-backend/routes.d.ts",
+      "default": "./dist/dashboard-backend/routes.js"
+    },
     "./metrics": {
       "types": "./dist/metrics/types.d.ts"
     },
@@ -54,6 +61,7 @@
     "typecheck": "tsc --noEmit",
     "generate": "tsx src/cli.ts",
     "generate:data": "tsx src/gen-data-types.ts",
+    "generate:dashboard-backend": "tsx src/gen-dashboard-backend-types.ts",
     "generate:metrics": "tsx src/gen-metrics-types.ts",
     "generate:repositories": "tsx src/gen-repositories-types.ts",
     "test": "vitest run",

--- a/src/dashboard-backend/routes.test.ts
+++ b/src/dashboard-backend/routes.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import * as routes from './routes.js'
+
+describe('dashboard-backend routes', () => {
+  it('declares only the favorite list, create, and delete routes', () => {
+    expect(Object.keys(routes)).toEqual(['favorite'])
+    expect(Object.keys(routes.favorite)).toEqual(['list', 'create', 'delete'])
+    expect(routes.favorite).toEqual({
+      list: {
+        method: 'GET',
+        path: '/favorites',
+        query: ['type'],
+      },
+      create: {
+        method: 'POST',
+        path: '/favorites',
+        hasRequestBody: true,
+      },
+      delete: {
+        method: 'DELETE',
+        path: '/favorites/{id}',
+      },
+    })
+  })
+})

--- a/src/dashboard-backend/routes.ts
+++ b/src/dashboard-backend/routes.ts
@@ -1,0 +1,18 @@
+import type { RouteDefinition } from '../gen/schema-types.js'
+
+export const favorite = {
+  list: {
+    method: 'GET',
+    path: '/favorites',
+    query: ['type'],
+  },
+  create: {
+    method: 'POST',
+    path: '/favorites',
+    hasRequestBody: true,
+  },
+  delete: {
+    method: 'DELETE',
+    path: '/favorites/{id}',
+  },
+} as const satisfies Record<string, RouteDefinition>

--- a/src/dashboard-backend/schemas.json
+++ b/src/dashboard-backend/schemas.json
@@ -1,0 +1,54 @@
+{
+  "GET /favorites": {
+    "request": null,
+    "responses": {
+      "200": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["id", "resource_id", "resource_name", "type"],
+          "properties": {
+            "id": { "type": "string" },
+            "resource_id": { "type": "string" },
+            "resource_name": { "type": "string" },
+            "type": { "type": "string" }
+          }
+        }
+      }
+    },
+    "request_example_count": 0,
+    "response_example_count": 0
+  },
+  "POST /favorites": {
+    "request": {
+      "type": "object",
+      "required": ["resource_id", "type"],
+      "properties": {
+        "resource_id": { "type": "string" },
+        "type": { "type": "string" }
+      }
+    },
+    "responses": {
+      "201": {
+        "type": "object",
+        "required": ["id", "resource_id", "type"],
+        "properties": {
+          "id": { "type": "string" },
+          "resource_id": { "type": "string" },
+          "type": { "type": "string" }
+        }
+      },
+      "204": {}
+    },
+    "request_example_count": 0,
+    "response_example_count": 0
+  },
+  "DELETE /favorites/:id": {
+    "request": null,
+    "responses": {
+      "204": {}
+    },
+    "request_example_count": 0,
+    "response_example_count": 0
+  }
+}

--- a/src/gen-dashboard-backend-types.test.ts
+++ b/src/gen-dashboard-backend-types.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it, vi } from 'vitest'
+import { favorite } from './dashboard-backend/routes.js'
+import { generateDashboardBackendTypes, main, type MainDeps } from './gen-dashboard-backend-types.js'
+
+const schemas = JSON.parse(
+  readFileSync(new URL('./dashboard-backend/schemas.json', import.meta.url), 'utf8'),
+)
+
+describe('generateDashboardBackendTypes', () => {
+  it('emits the favorite types and exact client method signatures', () => {
+    const out = generateDashboardBackendTypes({ favorite }, schemas)
+
+    expect(out).toMatch(/export type FavoriteListResult = Array<\{\s+id: string\s+resource_id: string\s+resource_name: string\s+type: string\s+\}>/)
+    expect(out).toMatch(/export interface FavoriteCreateOpts \{\s+resource_id: string\s+type: string\s+\}/)
+    expect(out).toMatch(/export interface FavoriteCreateResult \{\s+id: string\s+resource_id: string\s+type: string\s+\}/)
+    expect(out).not.toMatch(/export interface FavoriteCreateResult \{[^}]*resource_name/s)
+    expect(out).toContain('list(query: {')
+    expect(out).toMatch(/list\(query: \{\s+type\?: string\s+\}\): Promise<FavoriteListResult>/)
+    expect(out).toContain('create(requestBody: FavoriteCreateOpts): Promise<FavoriteCreateResult | void>')
+    expect(out).toContain('delete(id: string): Promise<void>')
+  })
+})
+
+describe('main', () => {
+  it('emits typed route source and writes types.d.ts and routes.d.ts', async () => {
+    const deps: Partial<MainDeps> = {
+      writeFile: vi.fn(),
+      emitTypedSource: vi.fn().mockReturnValue({
+        jsPath: '/fake/dist/dashboard-backend/routes.js',
+        diagnostics: [],
+      }),
+      log: vi.fn(),
+    }
+
+    await main(deps)
+
+    expect(deps.emitTypedSource).toHaveBeenCalledWith(expect.objectContaining({
+      sourcePath: expect.stringContaining('dashboard-backend/routes.ts'),
+    }))
+    expect(deps.writeFile).toHaveBeenCalledWith(
+      expect.stringContaining('dashboard-backend/types.d.ts'),
+      expect.stringContaining('HerokuClient'),
+    )
+    expect(deps.writeFile).toHaveBeenCalledWith(
+      expect.stringContaining('dashboard-backend/routes.d.ts'),
+      expect.stringContaining('favorite'),
+    )
+  })
+})

--- a/src/gen-dashboard-backend-types.ts
+++ b/src/gen-dashboard-backend-types.ts
@@ -1,0 +1,105 @@
+/**
+ * Code generator for `dashboard-backend/types.d.ts`.
+ *
+ * Reads:
+ *   - dashboard-backend/routes.ts       (hand-written resource grouping; (method, path) per call)
+ *   - dashboard-backend/schemas.json    (local response schemas keyed by "VERB /path")
+ *
+ * Emits dist/dashboard-backend/{types.d.ts, routes.js, routes.d.ts}.
+ *
+ * Usage: tsx src/gen-dashboard-backend-types.ts
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import { emitTypes } from "./gen/ts-emit.js";
+import {
+  normalizeData,
+  summarizeCoverage,
+  type RouteDef,
+  type RouteSchema,
+} from "./gen/normalize-data.js";
+import { emitTypedSource as defaultEmitTypedSource, type EmitTypedSourceResult } from "./gen/emit-typed-source.js";
+import { GENERATED_CONTENT_PREAMBLE } from "./gen/generator.js";
+import { generateRoutesDTSForResources } from "./gen/route-generator.js";
+
+export type { RouteDef, RouteSchema } from "./gen/normalize-data.js";
+export type { JsonSchema } from "./gen/normalize-data.js";
+
+const BANNER = "/**\n * NOTE: the contents of this file are generated. Do not modify this file.\n */\n";
+
+export function generateDashboardBackendTypes(
+  routesByResource: Record<string, Record<string, RouteDef>>,
+  schemas: Record<string, RouteSchema>,
+): string {
+  const model = normalizeData(routesByResource, schemas);
+  return BANNER + "\n" + emitTypes(model, { emitResourceShapes: false });
+}
+
+export interface MainDeps {
+  routesPath: string
+  schemaPath: string
+  outPath: string
+  readFile: (path: string) => string
+  writeFile: (path: string, content: string) => void
+  importRoutes: (path: string) => Promise<Record<string, unknown>>
+  emitTypedSource: (opts: { sourcePath: string; rootDir: string; outDir: string; banner?: string }) => EmitTypedSourceResult
+  log: (message: string) => void
+}
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SRC = HERE;
+const DIST = resolve(HERE, "../dist");
+
+const defaultDeps: MainDeps = {
+  routesPath: resolve(SRC, "dashboard-backend/routes.ts"),
+  schemaPath: resolve(SRC, "dashboard-backend/schemas.json"),
+  outPath: resolve(DIST, "dashboard-backend/types.d.ts"),
+  readFile: (p) => readFileSync(p, "utf8"),
+  writeFile: writeFileSync,
+  importRoutes: (p) => import(p),
+  emitTypedSource: defaultEmitTypedSource,
+  log: (m) => console.log(m),
+};
+
+export async function main(deps: Partial<MainDeps> = {}) {
+  const { routesPath, schemaPath, outPath, readFile, writeFile, importRoutes, emitTypedSource, log } = { ...defaultDeps, ...deps };
+
+  const routesModule = await importRoutes(routesPath);
+  const routesByResource: Record<string, Record<string, RouteDef>> = {};
+  for (const [k, v] of Object.entries(routesModule)) {
+    if (k !== "default") routesByResource[k] = v as Record<string, RouteDef>;
+  }
+
+  const schemas: Record<string, RouteSchema> = JSON.parse(readFile(schemaPath));
+  const output = generateDashboardBackendTypes(routesByResource, schemas);
+
+  const emitResult = emitTypedSource({
+    sourcePath: routesPath,
+    rootDir: SRC,
+    outDir: DIST,
+    banner: GENERATED_CONTENT_PREAMBLE,
+  });
+  if (emitResult.diagnostics.length > 0) {
+    const summary = emitResult.diagnostics.map(d => ts.flattenDiagnosticMessageText(d.messageText, '\n')).join('\n')
+    throw new Error(`emitTypedSource returned ${emitResult.diagnostics.length} diagnostic(s):\n${summary}`)
+  }
+
+  const routesDtsPath = resolve(DIST, "dashboard-backend/routes.d.ts");
+  writeFile(routesDtsPath, GENERATED_CONTENT_PREAMBLE + generateRoutesDTSForResources(Object.keys(routesByResource)));
+  writeFile(outPath, output);
+
+  const s = summarizeCoverage(routesByResource, schemas);
+  log(`Wrote ${outPath}`);
+  log(`Wrote ${emitResult.jsPath}`);
+  log(`Wrote ${routesDtsPath}`);
+  log(`  Methods total:        ${s.total}`);
+  log(`  With any schema:      ${s.withSchema} (${(100 * s.withSchema / s.total).toFixed(1)}%)`);
+  log(`  With request schema:  ${s.withOpts}`);
+  log(`  With response schema: ${s.withResult}`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main()
+}

--- a/src/gen-data-types.test.ts
+++ b/src/gen-data-types.test.ts
@@ -114,6 +114,21 @@ describe('generateDataTypes', () => {
     expect(out).not.toContain('AppDestroyResult')
   })
 
+  it('preserves an error-only response as the result when no 204 is declared', () => {
+    const out = generateDataTypes(
+      { app: { fail: { method: 'GET', path: '/apps/fail' } } },
+      {
+        'GET /apps/fail': routeSchema({
+          responses: {
+            '404': { type: 'object', properties: { message: { type: 'string' } } },
+          },
+        }),
+      },
+    )
+    expect(out).toContain('export interface AppFailResult')
+    expect(out).toMatch(/fail\(\): Promise<AppFailResult>/)
+  })
+
   it('uses other successful JSON responses as the principal result', () => {
     const out = generateDataTypes(
       { app: { partial: { method: 'GET', path: '/apps/partial' } } },
@@ -129,6 +144,22 @@ describe('generateDataTypes', () => {
     )
     expect(out).toContain('export interface AppPartialResult')
     expect(out).toMatch(/partial\(\): Promise<AppPartialResult \| void>/)
+  })
+
+  it('uses a 206-only response as the principal result without adding void', () => {
+    const out = generateDataTypes(
+      { app: { partial: { method: 'GET', path: '/apps/partial' } } },
+      {
+        'GET /apps/partial': routeSchema({
+          responses: {
+            '206': { type: 'object', properties: { id: { type: 'string' } } },
+          },
+        }),
+      },
+    )
+    expect(out).toContain('export interface AppPartialResult')
+    expect(out).toMatch(/partial\(\): Promise<AppPartialResult>/)
+    expect(out).not.toMatch(/partial\(\): Promise<AppPartialResult \| void>/)
   })
 
   it('matches schema keys regardless of {param} vs :param form', () => {

--- a/src/gen-data-types.test.ts
+++ b/src/gen-data-types.test.ts
@@ -72,6 +72,65 @@ describe('generateDataTypes', () => {
     expect(out).toMatch(/list\(\): Promise<unknown>/)
   })
 
+  it('includes void when a route has both a JSON response and no-content response', () => {
+    const out = generateDataTypes(
+      { app: { create: { method: 'POST', path: '/apps' } } },
+      {
+        'POST /apps': routeSchema({
+          responses: {
+            '201': { type: 'object', properties: { id: { type: 'string' } } },
+            '204': {},
+          },
+        }),
+      },
+    )
+    expect(out).toMatch(/create\(\): Promise<AppCreateResult \| void>/)
+  })
+
+  it('returns Promise<void> when a route has only a no-content response', () => {
+    const out = generateDataTypes(
+      { app: { destroy: { method: 'DELETE', path: '/apps/{name}' } } },
+      {
+        'DELETE /apps/:name': routeSchema({ responses: { '204': {} } }),
+      },
+    )
+    expect(out).toMatch(/destroy\(name: string\): Promise<void>/)
+    expect(out).not.toMatch(/destroy\(name: string\): Promise<unknown>/)
+  })
+
+  it('does not use an error response as the result for a no-content route', () => {
+    const out = generateDataTypes(
+      { app: { destroy: { method: 'DELETE', path: '/apps/{name}' } } },
+      {
+        'DELETE /apps/:name': routeSchema({
+          responses: {
+            '204': {},
+            '400': { type: 'object', properties: { message: { type: 'string' } } },
+          },
+        }),
+      },
+    )
+    expect(out).toMatch(/destroy\(name: string\): Promise<void>/)
+    expect(out).not.toContain('AppDestroyResult')
+  })
+
+  it('uses other successful JSON responses as the principal result', () => {
+    const out = generateDataTypes(
+      { app: { partial: { method: 'GET', path: '/apps/partial' } } },
+      {
+        'GET /apps/partial': routeSchema({
+          responses: {
+            '204': {},
+            '206': { type: 'object', properties: { id: { type: 'string' } } },
+            '400': { type: 'object', properties: { message: { type: 'string' } } },
+          },
+        }),
+      },
+    )
+    expect(out).toContain('export interface AppPartialResult')
+    expect(out).toMatch(/partial\(\): Promise<AppPartialResult \| void>/)
+  })
+
   it('matches schema keys regardless of {param} vs :param form', () => {
     const out = generateDataTypes(
       { app: { info: { method: 'GET', path: '/apps/{name}' } } },

--- a/src/gen/normalize-data.ts
+++ b/src/gen/normalize-data.ts
@@ -61,7 +61,9 @@ export function pickPrincipalResponse(
   for (const status of ['200', '201', '202']) {
     if (responses[status]) return responses[status]
   }
-  for (const v of Object.values(responses)) {
+  const hasNoContent = Object.prototype.hasOwnProperty.call(responses, '204')
+  for (const [status, v] of Object.entries(responses)) {
+    if (status === '204' || (hasNoContent && !/^2\d\d$/.test(status))) continue
     if (v) return v
   }
   return null
@@ -278,9 +280,22 @@ function buildMethod(
       },
     })
   }
-  const returnType: TypeRef = resultEmitted.has(p.resultName)
-    ? { kind: 'reference', name: p.resultName }
-    : { kind: 'primitive', primitive: 'unknown' }
+  const hasNoContent = p.schema !== null
+    && Object.prototype.hasOwnProperty.call(p.schema.responses, '204')
+  const hasResult = resultEmitted.has(p.resultName)
+  const returnType: TypeRef = hasResult && hasNoContent
+    ? {
+        kind: 'union',
+        members: [
+          { kind: 'reference', name: p.resultName },
+          { kind: 'primitive', primitive: 'void' },
+        ],
+      }
+    : hasResult
+      ? { kind: 'reference', name: p.resultName }
+      : hasNoContent
+        ? { kind: 'primitive', primitive: 'void' }
+        : { kind: 'primitive', primitive: 'unknown' }
   return { name: p.method, params, returnType }
 }
 


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary

Add typed Dashboard Backend favorites routes to `@heroku/types`.

Changes:

- Add the `favorite` route registry with:
  - `GET /favorites`
  - `POST /favorites`
  - `DELETE /favorites/{id}`
- Add request and response schemas for listing, creating, and deleting favorites.
- Generate and export `@heroku/types/dashboard-backend`.
- Generate and export `@heroku/types/dashboard-backend/routes`.
- Support no-content success responses in the curated types generator:
  - `201` plus `204` produces `Result | void`.
  - `204`-only responses produce `void`.
- Preserve existing fallback behavior for schemas that do not declare a `204` response.

Generated API:

```ts
favorite: {
  list(query: { type?: string }): Promise<FavoriteListResult>
  create(requestBody: FavoriteCreateOpts): Promise<FavoriteCreateResult | void>
  delete(id: string): Promise<void>
}
```

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [x] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing

CI should suffice.

## Screenshots (if applicable)

## Related Issues
GUS work item: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eLtxwYAC/view
