### PR TITLE
feat: add spaceDyno.list route to @heroku/types

### DIFF
--- a/dist/3.sdk/routes.d.ts
+++ b/dist/3.sdk/routes.d.ts
@@ -148,6 +148,8 @@ export declare const source: Record<string, RouteDefinition>
 
 export declare const spaceAppAccess: Record<string, RouteDefinition>
 
+export declare const spaceDyno: Record<string, RouteDefinition>
+
 export declare const spaceNat: Record<string, RouteDefinition>
 
 export declare const spaceTopology: Record<string, RouteDefinition>

--- a/dist/3.sdk/routes.js
+++ b/dist/3.sdk/routes.js
@@ -1225,6 +1225,13 @@ export const spaceAppAccess = {
   }
 }
 
+export const spaceDyno = {
+  "list": {
+    "method": "GET",
+    "path": "/spaces/{spaceIdentity}/dynos"
+  }
+}
+
 export const spaceNat = {
   "info": {
     "method": "GET",

--- a/dist/3.sdk/types.d.ts
+++ b/dist/3.sdk/types.d.ts
@@ -3277,6 +3277,14 @@ export interface SpaceAppAccessUpdateOpts {
   }>
 }
 
+/** Dynos running in a space, grouped by app. */
+export interface SpaceDyno {
+  /** unique name of app */
+  app_name: string
+  /** dynos running for this app in the space */
+  dynos: Array<Dyno>
+}
+
 /** Network address translation (NAT) for stable outbound IP addresses from a space */
 export interface SpaceNat {
   /** when network address translation for a space was created */
@@ -5577,6 +5585,11 @@ export interface HerokuClient {
     update(spaceIdentity: string, accountIdentity: string | '~', requestBody: SpaceAppAccessUpdateOpts): Promise<SpaceAppAccess>
     /** List all users and their permissions on a space. */
     list(spaceIdentity: string): Promise<Array<SpaceAppAccess>>
+  }
+  /** Dynos running in a space, grouped by app. */
+  spaceDyno: {
+    /** Current running dynos for a space, grouped by app. */
+    list(spaceIdentity: string): Promise<Array<SpaceDyno>>
   }
   /** Network address translation (NAT) for stable outbound IP addresses from a space */
   spaceNat: {

--- a/src/gen/patch-hyperschema.ts
+++ b/src/gen/patch-hyperschema.ts
@@ -14,12 +14,61 @@
 // and has NO schema, so this SELF-HEALS to a no-op if upstream ever adds the
 // schema block itself.
 
-import type { HerokuSchema, SchemaNode } from './schema-types.js'
+import type { HerokuSchema, ResourceDefinition, SchemaLink, SchemaNode } from './schema-types.js'
 
 const REFRESH_ACM_SCHEMA: SchemaNode = {
   type: ['object'],
   properties: { acm_refresh: { type: ['boolean'] } },
   required: ['acm_refresh'],
+}
+
+// WHY: The upstream hyperschema has no `space-dyno` resource at all, so
+// `GET /spaces/{spaceIdentity}/dynos` (used by the CLI's `heroku spaces:ps`)
+// has no generated route or type. We inject a minimal resource mirroring the
+// existing `space-host` "list of self" shape: each item is `{ app_name,
+// dynos }`, where `dynos` reuses the already-generated top-level `Dyno` type
+// via a resource-level $ref rather than duplicating its shape.
+//
+// The guard checks for the resource AND a GET/"instances" link on it, so this
+// SELF-HEALS to a no-op if upstream ever adds `space-dyno` (with or without
+// the list link) itself.
+const SPACE_DYNO_LIST_LINK: SchemaLink = {
+  title: 'List',
+  description: 'Current running dynos for a space, grouped by app.',
+  method: 'GET',
+  rel: 'instances',
+  href: '/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/dynos',
+  targetSchema: {
+    type: ['array'],
+    items: { $ref: '#/definitions/space-dyno' },
+  },
+}
+
+const SPACE_DYNO_DEFINITION: ResourceDefinition = {
+  description: 'Dynos running in a space, grouped by app.',
+  type: ['object'],
+  strictProperties: true,
+  definitions: {
+    app_name: {
+      description: 'unique name of app',
+      readOnly: true,
+      type: ['string'],
+    },
+  },
+  properties: {
+    app_name: { $ref: '#/definitions/space-dyno/definitions/app_name' },
+    dynos: {
+      description: 'dynos running for this app in the space',
+      readOnly: true,
+      type: ['array'],
+      items: { $ref: '#/definitions/dyno' },
+    },
+  },
+  links: [SPACE_DYNO_LIST_LINK],
+}
+
+function hasSpaceDynoListLink(links: SchemaLink[] | undefined): boolean {
+  return Boolean(links?.some(l => l.rel === 'instances' && l.method?.toUpperCase() === 'GET'))
 }
 
 // Mutates `schema` in place and returns it for chaining.
@@ -31,5 +80,16 @@ export function patchHyperschema(schema: HerokuSchema): HerokuSchema {
   if (link && !link.schema) {
     link.schema = REFRESH_ACM_SCHEMA
   }
+
+  const definitions = schema.definitions
+  if (definitions) {
+    const spaceDyno = definitions['space-dyno']
+    if (!spaceDyno) {
+      definitions['space-dyno'] = structuredClone(SPACE_DYNO_DEFINITION)
+    } else if (!hasSpaceDynoListLink(spaceDyno.links)) {
+      spaceDyno.links = [...(spaceDyno.links ?? []), structuredClone(SPACE_DYNO_LIST_LINK)]
+    }
+  }
+
   return schema
 }

--- a/tests/__golden__/3.sdk-types.d.ts
+++ b/tests/__golden__/3.sdk-types.d.ts
@@ -4797,6 +4797,14 @@ export interface UsageInfoGetResult {
   }>
 }
 
+/** Dynos running in a space, grouped by app. */
+export interface SpaceDyno {
+  /** unique name of app */
+  app_name: string
+  /** dynos running for this app in the space */
+  dynos: Array<Dyno>
+}
+
 export interface HerokuClient {
   /** A Heroku account becomes delinquent due to non-payment. We [suspend and delete](https://help.heroku.com/EREVRILX/what-happens-if-i-have-unpaid-heroku-invoices) delinquent accounts if their invoices remain unpaid. */
   accountDelinquency: {
@@ -5939,5 +5947,10 @@ export interface HerokuClient {
    * 
    */
   infoGet(teamIdentity: string): Promise<UsageInfoGetResult>
+  }
+  /** Dynos running in a space, grouped by app. */
+  spaceDyno: {
+  /** Current running dynos for a space, grouped by app. */
+  list(spaceIdentity: string): Promise<Array<SpaceDyno>>
   }
 }


### PR DESCRIPTION
## Summary

Adds a `spaceDyno` resource with a `list` link for `GET /spaces/{spaceIdentity}/dynos` to the generated `3.sdk` client, so `@heroku/sdk` consumers (and the CLI's `spaces:ps`) can list a space's dynos through a typed route. The route is absent from the upstream hyperschema, so it is injected via the sanctioned gap-fill.

### Details
- Add the `spaceDyno.list` route (`GET /spaces/{spaceIdentity}/dynos`) to `dist/3.sdk/routes.js` and `dist/3.sdk/routes.d.ts`.
- Add the `SpaceDyno` interface (`{ app_name, dynos: Dyno[] }`) and the `spaceDyno.list` method on `HerokuClient` in `dist/3.sdk/types.d.ts`.
- Inject the missing `space-dyno` resource + list link into `src/gen/patch-hyperschema.ts`, guarded to self-heal to a no-op if upstream later adds it.
- Update the golden test fixture (`tests/__golden__/3.sdk-types.d.ts`) to mirror the new type.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [x] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**:
`npm run generate` was deliberately **not** run — it re-fetches the live hyperschema and rewrites all of `dist/`, folding in unrelated upstream drift. The route was added minimally plus via `patch-hyperschema.ts` so a future regenerate stays in sync and self-heals to a no-op once upstream adds `space-dyno`.

**Steps**:
1. Passing CI suffices (vitest suite + `tsc --noEmit`; the route is also exercised by a `dist/3.sdk/routes.js` import check confirming `spaceDyno.list` is present).

## Screenshots (if applicable)

## Related Issues
GUS work item: [W-23384953](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eLuIvYAK/view) — Adopt `@heroku/sdk` in the spaces topic core lifecycle. Unblocks the CLI `spaces:ps` migration (deferred Phase 2), which needs this typed route.
