### PR TITLE
feat: patch space Create kpi_url and topology formations

### DIFF
--- a/src/gen/patch-hyperschema.test.ts
+++ b/src/gen/patch-hyperschema.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { generateTypes } from './generator.js'
 import { generateRoutesJS } from './route-generator.js'
 import { patchHyperschema } from './patch-hyperschema.js'
-import type { HerokuSchema } from './schema-types.js'
+import type { HerokuSchema, SchemaNode } from './schema-types.js'
 
 // The upstream hyperschema omits the request body on the app "Refresh ACM"
 // PATCH link, so the generator would emit no requestBody param and no
@@ -86,5 +86,170 @@ describe('patchHyperschema Refresh ACM injection', () => {
     }
     expect(() => patchHyperschema(schema)).not.toThrow()
     expect(schema.definitions.app.links![0].schema).toBeUndefined()
+  })
+})
+
+// The upstream hyperschema's space "Create" link doesn't declare a
+// `kpi_url` property, even though the API accepts it (spaces:create forwards
+// a hidden --kpi-url flag). patchHyperschema injects the optional property
+// so the generated SpaceCreateOpts type carries it without the CLI needing
+// an `as` cast.
+
+function schemaWithSpaceCreateLink(): HerokuSchema {
+  return {
+    definitions: {
+      space: {
+        definitions: {
+          identity: { type: ['string'] },
+        },
+        links: [
+          {
+            title: 'Create',
+            description: 'Create a new space.',
+            method: 'POST',
+            rel: 'create',
+            href: '/spaces',
+            schema: {
+              type: ['object'],
+              properties: {
+                name: { type: ['string'] },
+              },
+            },
+            targetSchema: { $ref: '#/definitions/space' },
+          },
+        ],
+      },
+    },
+  }
+}
+
+describe('patchHyperschema space Create kpi_url injection', () => {
+  it('adds kpi_url (optional, type string) to the Create link schema', () => {
+    const schema = schemaWithSpaceCreateLink()
+    patchHyperschema(schema)
+    const createLink = schema.definitions.space.links!.find(l => l.title === 'Create')!
+    expect(createLink.schema!.properties!.kpi_url).toEqual({ type: ['string'] })
+    expect(createLink.schema!.required ?? []).not.toContain('kpi_url')
+  })
+
+  it('self-heals to a no-op when kpi_url is already present', () => {
+    const schema = schemaWithSpaceCreateLink()
+    const existing: SchemaNode = { type: ['string'], description: 'already patched' }
+    schema.definitions.space.links![0].schema!.properties!.kpi_url = existing
+    patchHyperschema(schema)
+    expect(schema.definitions.space.links![0].schema!.properties!.kpi_url).toBe(existing)
+  })
+
+  it('does not throw when there is no space definition', () => {
+    const schema: HerokuSchema = { definitions: {} }
+    expect(() => patchHyperschema(schema)).not.toThrow()
+  })
+
+  it('does not throw when the space has no Create link', () => {
+    const schema: HerokuSchema = {
+      definitions: {
+        space: {
+          links: [{ title: 'Info', method: 'GET', href: '/spaces/{id}' }],
+        },
+      },
+    }
+    expect(() => patchHyperschema(schema)).not.toThrow()
+    expect(schema.definitions.space.links![0].schema).toBeUndefined()
+  })
+})
+
+// The upstream hyperschema's space-topology apps-item property is named
+// `formation` (singular), but the topology response is a straight
+// control-plane passthrough whose live payload key is `formations`
+// (plural) — the CLI has always read `app.formations`. patchHyperschema
+// renames the property KEY (not the $ref definition target) so the
+// generated SpaceTopology type matches the real payload.
+
+function schemaWithSpaceTopology(): HerokuSchema {
+  return {
+    definitions: {
+      'space-topology': {
+        definitions: {
+          formation: {
+            type: ['object'],
+            properties: {
+              type: { type: ['string'] },
+              quantity: { type: ['integer'] },
+            },
+          },
+        },
+        properties: {
+          apps: {
+            type: ['array'],
+            items: {
+              type: ['object'],
+              properties: {
+                name: { type: ['string'] },
+                formation: {
+                  type: ['array'],
+                  items: { $ref: '#/definitions/space-topology/definitions/formation' },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  }
+}
+
+describe('patchHyperschema space-topology formations rename', () => {
+  it('renames the apps-item formation property to formations, preserving shape', () => {
+    const schema = schemaWithSpaceTopology()
+    patchHyperschema(schema)
+    const appProps = schema.definitions['space-topology'].properties!.apps.items!.properties!
+    expect(appProps.formation).toBeUndefined()
+    expect(appProps.formations).toEqual({
+      type: ['array'],
+      items: { $ref: '#/definitions/space-topology/definitions/formation' },
+    })
+  })
+
+  it('leaves the $ref definition target named formation', () => {
+    const schema = schemaWithSpaceTopology()
+    patchHyperschema(schema)
+    expect(schema.definitions['space-topology'].definitions!.formation).toBeDefined()
+  })
+
+  it('self-heals to a no-op when formations is already present', () => {
+    const schema = schemaWithSpaceTopology()
+    const appItemProps = schema.definitions['space-topology'].properties!.apps.items!.properties!
+    const existing = appItemProps.formation
+    appItemProps.formations = existing
+    delete appItemProps.formation
+    patchHyperschema(schema)
+    expect(appItemProps.formations).toBe(existing)
+    expect(appItemProps.formation).toBeUndefined()
+  })
+
+  it('does not throw when there is no space-topology definition', () => {
+    const schema: HerokuSchema = { definitions: {} }
+    expect(() => patchHyperschema(schema)).not.toThrow()
+  })
+
+  it('does not throw when apps items have no formation property', () => {
+    const schema: HerokuSchema = {
+      definitions: {
+        'space-topology': {
+          properties: {
+            apps: {
+              type: ['array'],
+              items: {
+                type: ['object'],
+                properties: { name: { type: ['string'] } },
+              },
+            },
+          },
+        },
+      },
+    }
+    expect(() => patchHyperschema(schema)).not.toThrow()
+    const appProps = schema.definitions['space-topology'].properties!.apps.items!.properties!
+    expect(appProps.formations).toBeUndefined()
   })
 })

--- a/src/gen/patch-hyperschema.ts
+++ b/src/gen/patch-hyperschema.ts
@@ -89,6 +89,43 @@ export function patchHyperschema(schema: HerokuSchema): HerokuSchema {
     } else if (!hasSpaceDynoListLink(spaceDyno.links)) {
       spaceDyno.links = [...(spaceDyno.links ?? []), structuredClone(SPACE_DYNO_LIST_LINK)]
     }
+
+    // WHY: The upstream hyperschema's space "Create" link doesn't declare a
+    // `kpi_url` property on its request schema, even though the API accepts
+    // (and `spaces:create` forwards) a hidden `--kpi-url` flag for a
+    // self-managed KPI endpoint. Without this, the generated
+    // `SpaceCreateOpts` type lacks the field and the CLI has to `as`-cast
+    // around it.
+    //
+    // We inject the property here as optional (never added to `required`).
+    // The guard only fires when the Create link exists and has a `schema`,
+    // so this SELF-HEALS to a no-op if upstream ever adds the property
+    // itself.
+    const space = definitions['space']
+    const createLink = space?.links?.find(
+      l => l.title === 'Create' && l.method?.toUpperCase() === 'POST',
+    )
+    if (createLink?.schema) {
+      createLink.schema.properties ??= {}
+      createLink.schema.properties.kpi_url ??= { type: ['string'] }
+    }
+
+    // WHY: The upstream hyperschema's `space-topology` apps-item property is
+    // named `formation` (singular), but the topology response is a straight
+    // control-plane passthrough (not an API serializer), and the live
+    // payload key has always been `formations` (plural) — the CLI reads
+    // `app.formations`. We rename the property KEY here; the `$ref`
+    // definition target keeps its `formation` name.
+    //
+    // The guard only fires when `formation` is present and `formations` is
+    // absent, so this SELF-HEALS to a no-op if upstream ever renames the
+    // property itself (or if the property is absent entirely).
+    const spaceTopology = definitions['space-topology']
+    const topologyAppProps = spaceTopology?.properties?.['apps']?.items?.properties
+    if (topologyAppProps?.formation && !topologyAppProps.formations) {
+      topologyAppProps.formations = topologyAppProps.formation
+      delete topologyAppProps.formation
+    }
   }
 
   return schema


### PR DESCRIPTION
## Summary

Extend `patchHyperschema()` with two self-healing guards so the generated `@heroku/types` space definitions match what the API actually accepts, letting the CLI drop the two `as` casts it uses to paper over the current gaps.

- Add an optional `kpi_url` property to the space **Create** link schema (the API accepts `spaces:create --kpi-url`, but the upstream hyperschema omits it); never added to `required`.
- Rename the `space-topology` apps-item property key `formation` → `formations` to match the live control-plane passthrough payload the CLI already reads; the `$ref` definition target stays named `formation`.
- Add unit cases for both patches (mutation asserted + self-heal no-op), mirroring the existing Refresh-ACM / `space-dyno` test shape.

Both guards no-op if upstream ever lands the fix. This PR is the **generator change + tests only** — `dist/` regeneration is a separate release-time step (it fetches the live schema), so it is intentionally not included here.

## Type of Change

### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [x] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing

**Notes**: The generator patch is exercised entirely by unit tests (`src/gen/patch-hyperschema.test.ts`), which CI runs. `dist/` is not regenerated in this PR; the emitted output was verified locally (below) but a faithful `npm run generate` also snapshots unrelated live-schema drift, so committing regenerated types belongs to a dedicated release-prep PR.

**Steps**:
1. Passing CI suffices (unit tests cover both guards + their self-heal no-ops).
2. Local emitted-output check (optional, not committed): `npm run generate && npm run typecheck` clean; `grep -n "kpi_url" dist/3.sdk/types.d.ts` and `grep -n "formations" dist/3.sdk/types.d.ts` present, no singular topology `formation`.

## Screenshots (if applicable)

## Related Issues
GitHub issue: follow-up from review of heroku/cli#3881 (point #6)
GUS work item: [W-23943907](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002iO28LYAS/view)
