### PR TITLE
test: regenerate 3.sdk golden for kpi_url + topology formations

### DIFF
--- a/tests/__golden__/3.sdk-types.d.ts
+++ b/tests/__golden__/3.sdk-types.d.ts
@@ -3295,7 +3295,7 @@ export interface SpaceTopology {
     id?: string
     domains?: unknown[]
     /** formations for application */
-    formation?: Array<{
+    formations?: Array<{
       /** unique identifier of this process type */
       id?: string
       /** Name of process type */
@@ -3396,6 +3396,7 @@ export interface SpaceCreateOpts {
   supported_features?: unknown[]
   /** EKS version for the space infrastructure */
   eks_version?: string
+  kpi_url?: string
 }
 
 /** Stacks are the different application execution environments available in the Heroku platform. */


### PR DESCRIPTION
## Summary

Regenerate the `3.sdk` byte-for-byte golden fixture so it reflects the generator patch merged in #107, fixing the full-suite failure that blocks the release-please validate step on `main`.

- Regenerate `tests/__golden__/3.sdk-types.d.ts` from the committed fixture via `generateTypes` (not hand-edited).

The only two changed lines are the intended output of #107's `patchHyperschema` guards: `space-topology` app item `formation` → `formations`, and the added `kpi_url?: string` on `SpaceCreateOpts`. #107 patched the generator and its unit tests but did not refresh the golden that `tests/golden.test.ts` asserts against, so `vitest run` (which release validate runs) failed on `main`.

## Type of Change

### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [x] **test**: Add/update/remove tests

## Testing

**Notes**: Passing CI suffices — the change is a regenerated test fixture, and the golden regression test (`tests/golden.test.ts`) plus the full `vitest run` validate correctness. Locally: 156/156 passing.

**Steps**:
1. `npm test` — Expect: all test files pass (previously `tests/golden.test.ts` failed on the `3.sdk` byte-for-byte assertion).

## Screenshots (if applicable)

## Related Issues
GitHub issue: follow-up to #107 (fixes the release validate failure it introduced)
GUS work item: [W-23943907](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002iO28LYAS/view)
